### PR TITLE
GH-3: Add keyframe animation for Hello World text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Animated Hello World</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="hello-wrapper">
+      <p class="hello-text">Hello, World!</p>
+    </main>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,10 @@
   </head>
   <body>
     <main class="hello-wrapper">
-      <p class="hello-text">Hello, World!</p>
+      <div class="hello-content">
+        <p class="hello-text">Hello, World!</p>
+        <p class="hello-subtext">This is Ondine work.</p>
+      </div>
     </main>
   </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,83 @@
+:root {
+  --background: #020617;
+  --accent-1: #f87171;
+  --accent-2: #fbbf24;
+  --accent-3: #34d399;
+  --accent-4: #0ea5e9;
+  --foreground: #f8fafc;
+  --surface: rgba(15, 23, 42, 0.75);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.35), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(16, 185, 129, 0.25), transparent 35%),
+    var(--background);
+  color: var(--foreground);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.hello-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.hello-text {
+  padding: 1.5rem 2.75rem;
+  border-radius: 1.25rem;
+  font-size: clamp(2.6rem, 8vw, 4rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(2, 6, 23, 0.9));
+  box-shadow: 0 25px 35px rgba(2, 6, 23, 0.65);
+  color: var(--accent-1);
+  animation: helloGlow 8s ease-in-out infinite;
+  text-align: center;
+}
+
+@keyframes helloGlow {
+  0% {
+    opacity: 0;
+    transform: translateY(-1.5rem);
+    color: var(--accent-1);
+    text-shadow: 0 0 0 rgba(248, 113, 113, 0);
+  }
+  20% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  35% {
+    color: var(--accent-2);
+    text-shadow: 0 0 20px rgba(251, 191, 36, 0.45);
+  }
+  55% {
+    color: var(--accent-3);
+    text-shadow: 0 0 24px rgba(52, 211, 153, 0.5);
+  }
+  75% {
+    color: var(--accent-4);
+    text-shadow: 0 0 28px rgba(14, 165, 233, 0.55);
+  }
+  100% {
+    color: var(--accent-1);
+    text-shadow: 0 0 18px rgba(248, 113, 113, 0.6);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hello-text {
+    animation: none;
+    transform: none;
+    text-shadow: none;
+  }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -32,6 +32,13 @@ body {
   justify-content: center;
 }
 
+.hello-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
 .hello-text {
   padding: 1.5rem 2.75rem;
   border-radius: 1.25rem;
@@ -42,6 +49,15 @@ body {
   box-shadow: 0 25px 35px rgba(2, 6, 23, 0.65);
   color: var(--accent-1);
   animation: helloGlow 8s ease-in-out infinite;
+  text-align: center;
+}
+
+.hello-subtext {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: rgba(248, 250, 252, 0.85);
+  max-width: 28rem;
   text-align: center;
 }
 


### PR DESCRIPTION
Closes #3

## Changes
- Add a minimal `public/index.html` shell that loads `styles.css` and centers the greeting.
- Create `public/styles.css` with reusable color variables, the `helloGlow` keyframes, and a high-contrast layout for `.hello-text`.
- Honor `prefers-reduced-motion` by disabling the animation when requested so the page stays accessible.

## Notes
- `pnpm check` / `pnpm test` currently fail because the repository has no `package.json` yet.
