### PR TITLE
feat: add live view counter

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,11 +8,76 @@
   </head>
   <body>
     <main class="hello-wrapper">
+      <div class="view-badge" aria-live="polite">Views: --</div>
       <div class="hello-content">
         <h1 class="hello-text">Hello, World!</h1>
         <p class="hello-context">A gentle animated greeting served from Express.</p>
         <p class="hello-subtext">This is Ondine's work.</p>
       </div>
     </main>
+
+    <script>
+      (() => {
+        const badge = document.querySelector('.view-badge');
+        let pollTimer = null;
+
+        const renderViews = (views) => {
+          if (typeof views !== 'number' || Number.isNaN(views)) {
+            return;
+          }
+
+          badge.textContent = `Views: ${views}`;
+        };
+
+        const fetchViews = async () => {
+          try {
+            const response = await fetch('/api/views', { cache: 'no-store' });
+
+            if (!response.ok) {
+              throw new Error('Unable to fetch views');
+            }
+
+            const data = await response.json();
+            renderViews(data.views);
+            return true;
+          } catch (_) {
+            return false;
+          }
+        };
+
+        const startPolling = () => {
+          if (pollTimer) {
+            return;
+          }
+
+          pollTimer = setInterval(fetchViews, 10000);
+        };
+
+        const startRealtime = () => {
+          if (!('EventSource' in window)) {
+            startPolling();
+            return;
+          }
+
+          const source = new EventSource('/api/views/stream');
+
+          source.onmessage = (event) => {
+            try {
+              const data = JSON.parse(event.data);
+              renderViews(data.views);
+            } catch (_) {
+              // Keep current badge value if payload parsing fails.
+            }
+          };
+
+          source.onerror = () => {
+            source.close();
+            startPolling();
+          };
+        };
+
+        fetchViews().finally(startRealtime);
+      })();
+    </script>
   </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -26,6 +26,7 @@ body {
 }
 
 .hello-wrapper {
+  position: relative;
   width: min(32rem, 100%);
   padding: 2rem;
   border-radius: 1.5rem;
@@ -33,6 +34,20 @@ body {
   box-shadow: 0 25px 60px rgba(2, 6, 23, 0.6);
   text-align: center;
   animation: surfacePulse 10s ease-in-out infinite;
+}
+
+.view-badge {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(2, 6, 23, 0.72);
+  border: 1px solid rgba(248, 250, 252, 0.24);
+  color: rgba(248, 250, 252, 0.95);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 .hello-content {

--- a/server.js
+++ b/server.js
@@ -5,9 +5,42 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 const publicDir = path.join(__dirname, 'public');
+
+let viewCount = 0;
+const sseClients = new Set();
+
+const broadcastViews = () => {
+  const payload = `data: ${JSON.stringify({ views: viewCount })}\n\n`;
+
+  for (const client of sseClients) {
+    client.write(payload);
+  }
+};
+
 app.use(express.static(publicDir));
 
+app.get('/api/views', (req, res) => {
+  res.json({ views: viewCount });
+});
+
+app.get('/api/views/stream', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  res.write(`data: ${JSON.stringify({ views: viewCount })}\n\n`);
+  sseClients.add(res);
+
+  req.on('close', () => {
+    sseClients.delete(res);
+    res.end();
+  });
+});
+
 app.get('/', (req, res) => {
+  viewCount += 1;
+  broadcastViews();
   res.sendFile(path.join(publicDir, 'index.html'));
 });
 


### PR DESCRIPTION
## Summary
- add an in-memory root view counter on the Express server
- expose view count via `/api/views` and real-time updates via `/api/views/stream` (SSE)
- add a landing-page view badge that subscribes to SSE and falls back to polling when real-time updates fail

## Validation
- `pnpm install`
- `node --check server.js`

Closes #10